### PR TITLE
[TAS-72] Shard memory: logic insertion

### DIFF
--- a/sharding/src/node/config/shard_config.yaml
+++ b/sharding/src/node/config/shard_config.yaml
@@ -1,1 +1,3 @@
-memory_threshold: 5
+# Unavailable Memory Percentage should be set to a number between 0 and 100. For example, 5 means 5%.
+# This is the percentage of the total memory that is reserved for the system and other procedures and is not available for storing data.
+unavailable_memory_perc: 5

--- a/sharding/src/node/memory_manager.rs
+++ b/sharding/src/node/memory_manager.rs
@@ -4,33 +4,32 @@ use std::ffi::CString;
 use std::io;
 use sysinfo::System;
 
+/// This struct represents the Memory Manager in the distributed system.
+/// It will manage the memory of the node and will be used to determine if the node should accept new requests.
+/// It holds the unavailable_memory_perc, which is the percentage of memory that should not be used and is reserved for the system to use for other purposes.
 pub struct MemoryManager {
-    memory_threshold: f64,
+    unavailable_memory_perc: f64,
     pub available_memory_perc: f64,
 }
 
 impl MemoryManager {
-    pub fn new(memory_threshold: f64) -> Self {
-        let available_memory_perc = match Self::get_available_memory_percentage() {
+    pub fn new(unavailable_memory_perc: f64) -> Self {
+        let available_memory_perc = match Self::get_available_memory_percentage(unavailable_memory_perc) {
             Some(perc) => perc,
             None => panic!("[MemoryManager] Failed to get available memory"),
         };
         println!(
-            "{color_blue}[Memory Manager] Memory Threshold: {:?}{style_reset}",
-            memory_threshold
+            "{color_blue}[Memory Manager] Memory Threshold: {:?}%{style_reset}",
+            unavailable_memory_perc
         );
         MemoryManager {
-            memory_threshold,
+            unavailable_memory_perc,
             available_memory_perc,
         }
     }
 
-    pub fn accepts_insertions(&self) -> bool {
-        self.available_memory_perc > self.memory_threshold
-    }
-
     pub fn update(&mut self) -> Result<(), io::Error> {
-        self.available_memory_perc = match Self::get_available_memory_percentage() {
+        self.available_memory_perc = match Self::get_available_memory_percentage(self.unavailable_memory_perc) {
             Some(perc) => perc,
             None => {
                 return Err(io::Error::new(
@@ -42,7 +41,11 @@ impl MemoryManager {
         Ok(())
     }
 
-    fn get_available_memory_percentage() -> Option<f64> {
+    fn get_available_memory_percentage(unavailable_memory_perc: f64) -> Option<f64> {
+        if unavailable_memory_perc == 100.0 {
+            return Some(0.0);
+        }
+
         // Create a System object
         let mut sys = System::new_all();
 
@@ -57,9 +60,60 @@ impl MemoryManager {
             let total_space = ((stat.f_blocks as u64) * stat.f_frsize) / 1024;
             let available_space = ((stat.f_bavail as u64) * stat.f_frsize) / 1024;
 
-            Some((available_space as f64 / total_space as f64) * 100.0)
+            // if percentage is greater than 1, it means that the total of space used exceeds the threshold.
+            // If so, return 0
+            let total = total_space as f64;
+            let threshold_size = total * (unavailable_memory_perc / 100.0);
+
+            if threshold_size > available_space as f64 {
+                println!(
+                    "{color_red}[Memory Manager] Memory Threshold Exceeded Available Space{style_reset}"
+                );
+                return Some(0.0);
+            }
+            
+            let usable_available_space = available_space as f64 - threshold_size;
+            let usable_total_space = total - threshold_size / 100.0;
+            
+            let percentage = usable_available_space / usable_total_space * 100.0;
+            if percentage > 100.0 {
+                return Some(0.0);
+            }
+            println!(
+                "{color_blue}[Memory Manager] Available Memory: {:?} %{style_reset}",
+                percentage
+            );
+            Some(percentage)
         } else {
             None
         }
+    }
+}
+
+
+#[cfg(test)]
+
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_get_available_memory_percentage() {
+        let unavailable_memory_perc = 0.0;
+        let available_memory_perc = MemoryManager::get_available_memory_percentage(unavailable_memory_perc);
+        assert_eq!(available_memory_perc.is_some(), true);
+    }
+
+    #[test]
+    fn test_get_available_memory_percentage_threashold_is_total() {
+        let unavailable_memory_perc = 100.0;
+        let available_memory_perc = MemoryManager::get_available_memory_percentage(unavailable_memory_perc).unwrap();
+        assert_eq!(available_memory_perc, 0.0);
+    }
+
+    #[test]
+    fn test_get_available_memory_percentage_threashold_exceeds_available_space() {
+        let unavailable_memory_perc = 90.0;
+        let available_memory_perc = MemoryManager::get_available_memory_percentage(unavailable_memory_perc).unwrap();
+        assert_eq!(available_memory_perc, 0.0);
     }
 }

--- a/sharding/src/node/messages/message.rs
+++ b/sharding/src/node/messages/message.rs
@@ -6,7 +6,6 @@ pub enum MessageType {
     InitConnection,
     AskMemoryUpdate,
     MemoryUpdate,
-    AskInsertionAcceptance,
     Agreed,
     Denied,
 }
@@ -45,7 +44,6 @@ impl Message {
             MessageType::InitConnection => "INIT_CONNECTION",
             MessageType::AskMemoryUpdate => "ASK_MEMORY_UPDATE",
             MessageType::MemoryUpdate => "MEMORY_UPDATE",
-            MessageType::AskInsertionAcceptance => "ASK_INSERTION_ACCEPTANCE",
             MessageType::Agreed => "AGREED",
             MessageType::Denied => "DENIED",
         });
@@ -68,7 +66,6 @@ impl Message {
             Some("INIT_CONNECTION") => MessageType::InitConnection,
             Some("ASK_MEMORY_UPDATE") => MessageType::AskMemoryUpdate,
             Some("MEMORY_UPDATE") => MessageType::MemoryUpdate,
-            Some("ASK_INSERTION_ACCEPTANCE") => MessageType::AskInsertionAcceptance,
             Some("AGREED") => MessageType::Agreed,
             Some("DENIED") => MessageType::Denied,
             _ => return Err("Invalid message type"),

--- a/sharding/src/node/router.rs
+++ b/sharding/src/node/router.rs
@@ -1,7 +1,7 @@
 use postgres::{Client, NoTls};
 extern crate users;
 use crate::node::messages::message::{Message, MessageType};
-use crate::utils::queries::query_is_insert;
+use crate::utils::queries::{query_affects_memory_state, query_is_insert};
 
 use super::node::*;
 use super::shard_manager::ShardManager;
@@ -11,7 +11,7 @@ use inline_colorization::*;
 use rust_decimal::Decimal;
 use std::collections::HashMap;
 use std::io::{Read, Write};
-use std::sync::{Arc, RwLock};
+use std::sync::{Arc, MutexGuard, RwLock};
 use std::{io, net::TcpStream, sync::Mutex};
 
 // use super::super::utils::sysinfo::print_available_memory;
@@ -246,55 +246,19 @@ impl Router {
         }
     }
 
-    /// Function that receives a query and checks for shards
-    /// with corresponding data
-    fn get_shards_for_query(&self, query: &str) -> (Vec<String>, bool) {
-        // If it's an INSERT query, return specific Shards.
+    /// Function that receives a query and checks for shards with corresponding data.
+    /// If the query is an INSERT query, it will return the specific shard that the query should be sent to.
+    /// If the query is not an INSERT query, it will return all shards.
+    /// The second return value is a boolean that indicates if the shards need to update their memory after the query is executed. This will be true if the query affects the memory state of the system.
+    fn get_shards_for_query(&mut self, query: &str) -> (Vec<String>, bool) {
         if query_is_insert(query) {
             println!("Query is INSERT");
-
             let shard = self.shard_manager.peek().unwrap();
-            println!(
-                "{color_bright_white}{style_bold}Returning shard: {}{style_reset}",
-                shard
-            );
-
-            // TODO-SHARD: ask shard if it accepts insertions. If it does, pop it from the ShardManager and then update it.
-            // If it doesn't, think of a way to handle this situation
-
             (vec![shard.clone()], true)
         } else {
             // Return all shards
-            println!("{color_bright_white}{style_bold}Returning all shards{style_reset}");
-            (self.shards.lock().unwrap().keys().cloned().collect(), false)
+            (self.shards.lock().unwrap().keys().cloned().collect(), query_affects_memory_state(query))
         }
-    }
-
-    /// Function that sends a message to the shard asking for a memory update. This must be called each time an insertion query is sent, and may be used to update the shard's memory size in the ShardManager in other circumstances.
-    fn ask_for_memory_update(&mut self, shard_id: String) {
-        // Get channel
-        let self_clone = self.clone();
-        let comm_channels = self_clone.comm_channels.read().unwrap();
-        let shard_comm_channel = comm_channels.get(&shard_id).unwrap();
-        let mut stream = shard_comm_channel.stream.as_ref().lock().unwrap();
-
-        // Write message
-        let message = Message::new(MessageType::AskMemoryUpdate, None);
-        stream.write(message.to_string().as_bytes()).unwrap();
-        let mut response: [u8; 1024] = [0; 1024];
-
-        // Readn and handle message
-        stream.read(&mut response).unwrap();
-        let response_string = String::from_utf8_lossy(&response);
-        let response_message = match Message::from_string(&response_string) {
-            Ok(message) => message,
-            Err(_) => {
-                eprintln!("Failed to parse message from shard");
-                // TODO-SHARD: handle this situation, should this try again? What happens if we can't update the shard's memory in the shard_manager?
-                return;
-            }
-        };
-        self.handle_response(response_message, shard_id.as_str());
     }
 }
 
@@ -316,8 +280,72 @@ impl NodeRole for Router {
     }
 }
 
+// Communication with shards
 impl Router {
-    fn send_query_to_shard(&mut self, shard_id: String, query: &str, is_insert: bool) {
+
+    fn get_stream(&self, shard_id: &str) -> Option<Arc<Mutex<TcpStream>>> {
+        let comm_channels = match self.comm_channels.read() {
+            Ok(comm_channels) => comm_channels,
+            Err(_) => {
+                eprintln!("Failed to get comm channels");
+                return None;
+            }
+        };
+
+        let shard_comm_channel = match comm_channels.get(&shard_id.to_string()) {
+            Some(shard_comm_channel) => shard_comm_channel,
+            None => {
+                eprintln!("Failed to get comm channel for shard {}", shard_id);
+                return None;
+            }
+        };
+
+        Some(shard_comm_channel.stream.clone())
+    }
+
+    fn init_message_exchange(&mut self, message: Message, writable_stream: &mut MutexGuard<TcpStream>, shard_id: String) -> bool {
+        writable_stream.write(message.to_string().as_bytes()).unwrap();
+        let mut response: [u8; 1024] = [0; 1024];
+
+        // Readn and handle message
+        writable_stream.read(&mut response).unwrap();
+        let response_string = String::from_utf8_lossy(&response);
+        let response_message = match Message::from_string(&response_string) {
+            Ok(message) => message,
+            Err(_) => {
+                eprintln!("Failed to parse message from shard");
+                // TODO-SHARD: handle this situation, should this try again? What happens if we can't update the shard's memory in the shard_manager?
+                return false;
+            }
+        };
+        
+        self.handle_response(response_message, shard_id.as_str())
+    }
+
+    /// Function that sends a message to the shard asking for a memory update. This must be called each time an insertion query is sent, and may be used to update the shard's memory size in the ShardManager in other circumstances.
+    fn ask_for_memory_update(&mut self, shard_id: String) {
+        let stream = match self.get_stream(shard_id.as_str()) {
+            Some(stream) => stream,
+            None => {
+                eprintln!("Failed to get stream for shard {}", shard_id);
+                return;
+            }
+        };
+
+        let mut writable_stream = match stream.as_ref().try_lock() {
+            Ok(writable_stream) => writable_stream,
+            Err(_) => {
+                eprintln!("Failed to get writable stream for shard {}", shard_id);
+                return;
+            }
+        };
+
+        // Write message
+        let message = Message::new(MessageType::AskMemoryUpdate, None);
+        self.init_message_exchange(message, &mut writable_stream, shard_id);
+    }
+
+    fn send_query_to_shard(&mut self, shard_id: String, query: &str, update: bool) {
         if let Some(shard) = self.clone().shards.lock().unwrap().get_mut(&shard_id) {
             let rows = match shard.query(query, &[]) {
                 Ok(rows) => rows,
@@ -327,7 +355,7 @@ impl Router {
                 }
             };
 
-            if is_insert {
+            if update {
                 self.ask_for_memory_update(shard_id);
             }
 

--- a/sharding/src/utils/node_config.rs
+++ b/sharding/src/utils/node_config.rs
@@ -15,7 +15,7 @@ pub struct Node {
 
 #[derive(Debug, Deserialize)]
 pub struct LocalNode {
-    pub memory_threshold: f64,
+    pub unavailable_memory_perc: f64,
 }
 
 pub fn get_router_config(config_file_path: Option<&str>) -> NodesConfig {

--- a/sharding/src/utils/queries.rs
+++ b/sharding/src/utils/queries.rs
@@ -1,3 +1,25 @@
+struct QueryTypes;
+
+impl QueryTypes {
+    const INSERT: &'static str = "INSERT";
+    const DELETE: &'static str = "DELETE";
+    const DROP: &'static str = "DROP";
+    const UPDATE: &'static str = "UPDATE";
+    const CREATE: &'static str = "CREATE";
+}
+
 pub fn query_is_insert(query: &str) -> bool {
-    query.to_uppercase().starts_with("INSERT")
+    query_is(query, QueryTypes::INSERT)
+}
+
+fn query_is(query: &str, query_type: &str) -> bool {
+    query.to_uppercase().starts_with(query_type)
+}
+
+pub fn query_affects_memory_state(query: &str) -> bool {
+    query_is(query, QueryTypes::INSERT) ||
+    query_is(query, QueryTypes::DELETE) ||
+    query_is(query, QueryTypes::DROP) ||
+    query_is(query, QueryTypes::UPDATE) ||
+    query_is(query, QueryTypes::CREATE)
 }


### PR DESCRIPTION
# [TAS-66] [Subtask] Se debe considerar si Shard acepta inserciones

## Description
Shard should not use the reserved memory given by the config file.

### Changes
- Memory Manager now considers the reserved memory into the % of memory available
- Delete unused methods and others

## Checklist
[Check all of the boxes you match, and explain why if not checked]
- [x] New unit tests added. Why (if not):
- [x] All unit tests passed
