### PR TITLE
Modularize shard

### DIFF
--- a/sharding/Cargo.toml
+++ b/sharding/Cargo.toml
@@ -25,8 +25,8 @@ sysinfo = "0.30.13"
 indexmap = "2.5.0"
 actix = "0.13.5"
 actix-rt = "2.0"
-# raft = { git = "https://github.com/isoprophlex/raft", branch = "master" }
-raft = { path = "../../raft" }
+raft = { git = "https://github.com/isoprophlex/raft", branch = "master" }
+# raft = { path = "../../raft" }
 
 
 [lib]

--- a/sharding/Cargo.toml
+++ b/sharding/Cargo.toml
@@ -27,6 +27,8 @@ actix = "0.13.5"
 actix-rt = "2.0"
 raft = { git = "https://github.com/isoprophlex/raft", branch = "master" }
 # raft = { path = "../../raft" }
+log = "0.4"
+env_logger = "0.10"
 
 
 [lib]

--- a/sharding/src/main.rs
+++ b/sharding/src/main.rs
@@ -1,1 +1,3 @@
-fn main() {}
+fn main() {
+    env_logger::init();
+}

--- a/sharding/src/node/node.rs
+++ b/sharding/src/node/node.rs
@@ -3,7 +3,6 @@ use crate::utils::node_config::get_nodes_config_raft;
 
 use super::router::Router;
 use super::shard::Shard;
-use actix_rt::System;
 use std::ffi::CStr;
 use std::sync::{Arc, Mutex};
 use std::thread;

--- a/sharding/src/node/node.rs
+++ b/sharding/src/node/node.rs
@@ -185,7 +185,7 @@ fn init_shard(ip: &str, port: &str) {
     let ip_clone = ip.to_string();
     let port_clone = port.to_string();
     let _handle = thread::spawn(move || {
-        Shard::accept_connections(shared_shard, ip_clone, port_clone);
+        Shard::accept_connections(&shared_shard, &ip_clone, &port_clone);
     });
 
     println!("Sharding node initializes");

--- a/sharding/src/node/shard.rs
+++ b/sharding/src/node/shard.rs
@@ -161,32 +161,13 @@ impl Shard {
 
         match message.get_message_type() {
             MessageType::InitConnection => {
-                let router_info = message.get_data().node_info.unwrap();
-                self.router_info = Arc::new(Mutex::new(Some(router_info.clone())));
-                println!("{color_bright_green}Received an InitConnection message{style_reset}");
-                let response_string = self.get_agreed_connection();
-                Some(response_string)
+                self.handle_init_connection_message(message)
             }
             MessageType::AskMemoryUpdate => {
-                println!("{color_bright_green}Received an AskMemoryUpdate message{style_reset}");
-                let response_string = self.get_memory_update_message();
-                Some(response_string)
+                self.handle_memory_update_message()
             }
             MessageType::GetRouter => {
-                println!("{color_bright_green}Received a GetRouter message{style_reset}");
-                let self_clone = self.clone();
-                let router_info: Option<NodeInfo> = {
-                    let router_info = self_clone.router_info.as_ref().try_lock().unwrap();
-                    router_info.clone()
-                };
-
-                if let Some(router_info) = router_info {
-                    let response_message = Message::new_router_id(router_info.clone());
-                    Some(response_message.to_string())
-                } else {
-                    let response_message = Message::new_no_router_data();
-                    Some(response_message.to_string())
-                }
+                self.handle_get_router_message()
             }
             _ => {
                 eprintln!(
@@ -195,6 +176,37 @@ impl Shard {
                 );
                 None
             }
+        }
+    }
+
+    fn handle_init_connection_message(&mut self, message: Message) -> Option<String> {
+        let router_info = message.get_data().node_info.unwrap();
+        self.router_info = Arc::new(Mutex::new(Some(router_info.clone())));
+        println!("{color_bright_green}Received an InitConnection message{style_reset}");
+        let response_string = self.get_agreed_connection();
+        Some(response_string)
+    }
+
+    fn handle_memory_update_message(&mut self) -> Option<String> {
+        println!("{color_bright_green}Received an AskMemoryUpdate message{style_reset}");
+        let response_string = self.get_memory_update_message();
+        Some(response_string)
+    }
+
+    fn handle_get_router_message(&mut self) -> Option<String> {
+        println!("{color_bright_green}Received a GetRouter message{style_reset}");
+        let self_clone = self.clone();
+        let router_info: Option<NodeInfo> = {
+            let router_info = self_clone.router_info.as_ref().try_lock().unwrap();
+            router_info.clone()
+        };
+
+        if let Some(router_info) = router_info {
+            let response_message = Message::new_router_id(router_info.clone());
+            Some(response_message.to_string())
+        } else {
+            let response_message = Message::new_no_router_data();
+            Some(response_message.to_string())
         }
     }
 

--- a/sharding/src/node/shard.rs
+++ b/sharding/src/node/shard.rs
@@ -42,17 +42,14 @@ impl fmt::Debug for Shard {
 }
 
 impl Shard {
-    /// Creates a new Shard node with the given port
+    /// Creates a new Shard node in the given port.
     pub fn new(ip: &str, port: &str) -> Self {
-        println!("Creating a new Shard node with port: {}", port);
-        println!("Connecting to the database with port: {}", port);
+        println!("Creating a new Shard node in port: {}", port);
+        println!("Connecting to the database in port: {}", port);
 
         let backend: PostgresClient = connect_to_node(ip, port).unwrap();
 
-        // Initialize memory manager
-        let config = get_memory_config();
-        let reserved_memory = config.unavailable_memory_perc;
-        let memory_manager = MemoryManager::new(reserved_memory);
+        let memory_manager = Self::initialize_memory_manager();        
 
         println!(
             "{color_blue}[Shard] Available Memory: {:?} %{style_reset}",
@@ -73,6 +70,12 @@ impl Shard {
             shard
         );
         shard
+    }
+
+    fn initialize_memory_manager() -> MemoryManager {
+        let config = get_memory_config();
+        let reserved_memory = config.unavailable_memory_perc;
+        MemoryManager::new(reserved_memory)
     }
 
     pub fn accept_connections(shared_shard: Arc<Mutex<Shard>>, ip: String, port: String) {

--- a/sharding/src/node/shard.rs
+++ b/sharding/src/node/shard.rs
@@ -161,15 +161,9 @@ impl Shard {
         };
 
         match message.get_message_type() {
-            MessageType::InitConnection => {
-                self.handle_init_connection_message(message)
-            }
-            MessageType::AskMemoryUpdate => {
-                self.handle_memory_update_message()
-            }
-            MessageType::GetRouter => {
-                self.handle_get_router_message()
-            }
+            MessageType::InitConnection => self.handle_init_connection_message(message),
+            MessageType::AskMemoryUpdate => self.handle_memory_update_message(),
+            MessageType::GetRouter => self.handle_get_router_message(),
             _ => {
                 error!(
                     "Message type received: {:?}, not yet implemented",


### PR DESCRIPTION
- Simplify code's readability by extracting some of the behavior to private functions.
- Change println! for logs, to allow us to separate which log levels we want to print in the terminal.
- Used references when we weren't consuming a variable that arrived to a function by parameter.
- Added must_use tag to Shard::new(), to prevent the users from ignoring the return value.
- Applied some clippy suggestions